### PR TITLE
Fix invalid credentials for superadmin

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -36,8 +36,14 @@ export async function POST(request: NextRequest) {
     const user = results[0]
 
     // Fallback: accept default demo password if hash missing or column absent
-    const storedHash = (user as any).password_hash || '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi'
-    const isValidPassword = await bcrypt.compare(password, storedHash)
+    const storedHashRaw =
+      (user as any).password_hash ||
+      '$2y$10$2LsVYo6Mid1LkohJdUDMeeLKvS5eiU5MsP/mnouNEJSRQAbQgLcPC' // default to demo password "password123"
+
+    // Support PHP/Laravel bcrypt hashes that use the "$2y$" prefix
+    const normalizedHash = storedHashRaw.replace(/^\$2y\$/i, '$2a$')
+
+    const isValidPassword = await bcrypt.compare(password, normalizedHash)
     if (!isValidPassword) {
       return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 })
     }

--- a/lib/migration.ts
+++ b/lib/migration.ts
@@ -208,6 +208,22 @@ const migrations: Migration[] = [
       ALTER TABLE transactions ADD COLUMN IF NOT EXISTS metadata TEXT NULL;
     `,
   },
+  {
+    id: 8,
+    name: "set_demo_users_password_to_password123",
+    sql: `
+      -- Update demo users to use 'password123' (Laravel-style $2y$ bcrypt hash)
+      UPDATE users 
+      SET password_hash = '$2y$10$2LsVYo6Mid1LkohJdUDMeeLKvS5eiU5MsP/mnouNEJSRQAbQgLcPC'
+      WHERE email IN (
+        'superadmin@familystore.com',
+        'admin@familystore.com',
+        'kasir1@familystore.com',
+        'kasir2@familystore.com'
+      )
+      OR password_hash = '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi';
+    `,
+  },
 ]
 
 export async function runMigrations() {


### PR DESCRIPTION
Normalize bcrypt hashes and update demo user passwords to fix "Invalid credentials" for Laravel-style hashes and ensure "password123" works.

The `bcrypt.compare` function in Node.js expects hashes to start with `$2a$` or `$2b$`, but Laravel often generates `$2y$`. This change normalizes the `$2y$` prefix to `$2a$` to allow successful comparison. Additionally, a migration updates existing demo user passwords to a new `$2y$` hash for "password123" to align with the requested login criteria.

---
<a href="https://cursor.com/background-agent?bcId=bc-d12300dc-3c8d-45d6-bd39-f3a32d47282c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d12300dc-3c8d-45d6-bd39-f3a32d47282c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

