### PR TITLE
Fix invalid credentials for superadmin

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -37,7 +37,13 @@ export async function POST(request: NextRequest) {
 
     // Fallback: accept default demo password if hash missing or column absent
     const storedHash = (user as any).password_hash || '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi'
-    const isValidPassword = await bcrypt.compare(password, storedHash)
+
+    // Normalize Laravel/PHP bcrypt hashes ($2y$) to a compatible prefix for bcryptjs ($2a$)
+    const normalizedHash = storedHash.startsWith('$2y$')
+      ? `$2a$${storedHash.slice(4)}`
+      : storedHash
+
+    const isValidPassword = await bcrypt.compare(password, normalizedHash)
     if (!isValidPassword) {
       return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 })
     }

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -71,8 +71,8 @@ export function LoginForm() {
             <p className="font-medium">Demo Akun:</p>
             <p>Super Admin: superadmin@familystore.com</p>
             <p>Admin: admin@familystore.com</p>
-            <p>Kasir: kasir@familystore.com</p>
-            <p className="text-xs mt-1">Password: password123</p>
+            <p>Kasir: kasir1@familystore.com</p>
+            <p className="text-xs mt-1">Password: password</p>
           </div>
         </CardContent>
       </Card>

--- a/lib/migration.ts
+++ b/lib/migration.ts
@@ -208,6 +208,16 @@ const migrations: Migration[] = [
       ALTER TABLE transactions ADD COLUMN IF NOT EXISTS metadata TEXT NULL;
     `,
   },
+  {
+    id: 8,
+    name: "set_superadmin_password_hash",
+    sql: `
+      -- Ensure superadmin has the specified bcrypt hash (Laravel style $2y$)
+      UPDATE users 
+      SET password_hash = '$2y$10$2LsVYo6Mid1LkohJdUDMeeLKvS5eiU5MsP/mnouNEJSRQAbQgLcPC'
+      WHERE email = 'superadmin@familystore.com';
+    `,
+  },
 ]
 
 export async function runMigrations() {


### PR DESCRIPTION
Fix "Invalid credentials" error by normalizing Laravel-style bcrypt hashes in the login API, updating the superadmin's password via migration, and correcting demo login credentials.

---
<a href="https://cursor.com/background-agent?bcId=bc-0d8e1a6f-8125-4070-bd0d-bf6449a21ca5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0d8e1a6f-8125-4070-bd0d-bf6449a21ca5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

