### PR TITLE
Create vscode repo manager extension

### DIFF
--- a/vscode-repo-manager/.gitignore
+++ b/vscode-repo-manager/.gitignore
@@ -1,0 +1,4 @@
+out/
+node_modules/
+.vscode-test/
+*.vsix

--- a/vscode-repo-manager/.vscodeignore
+++ b/vscode-repo-manager/.vscodeignore
@@ -1,0 +1,6 @@
+out/test/**
+src/**
+.vscode/**
+.vscode-test/**
+node_modules/**
+**/*.map

--- a/vscode-repo-manager/README.md
+++ b/vscode-repo-manager/README.md
@@ -1,0 +1,37 @@
+# Repo Manager (VS Code Extension)
+
+Manage and open your Git repositories from a dedicated Activity Bar view.
+
+## Features
+
+- Repositories view with quick open
+- Scan workspace for repos (by finding `.git/config`)
+- Add/remove repositories manually
+- Clone into selected folder
+- Git actions via integrated terminal: Fetch, Pull, Push
+- Persistent repo list across sessions (stored in global state)
+
+## Commands
+
+- Repo Manager: Refresh
+- Repo Manager: Scan Workspace for Repos
+- Repo Manager: Add Repository Folder
+- Repo Manager: Clone Repository
+- Repo Manager: Open Repository
+- Repo Manager: Remove Repository
+- Repo Manager: Fetch / Pull / Push
+
+## Settings
+
+- `repoManager.autoScanOnStartup` (boolean, default: true)
+- `repoManager.openInNewWindow` (boolean, default: false)
+- `repoManager.includeGlobs` (array of globs, default: `["**/.git/config"]`)
+- `repoManager.excludeGlobs` (array of globs)
+
+## Development
+
+- Install dependencies: `npm install`
+- Build: `npm run compile`
+- Watch: `npm run watch`
+- Launch Extension: Press F5 from VS Code to launch Extension Development Host.
+

--- a/vscode-repo-manager/media/activity-icon.svg
+++ b/vscode-repo-manager/media/activity-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 3h18v18H3z"/>
+  <path d="M7 15l3-3 2 2 4-4 1 1"/>
+</svg>

--- a/vscode-repo-manager/package-lock.json
+++ b/vscode-repo-manager/package-lock.json
@@ -1,0 +1,58 @@
+{
+  "name": "vscode-repo-manager",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vscode-repo-manager",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/node": "^20.14.11",
+        "@types/vscode": "^1.95.0",
+        "typescript": "^5.6.3"
+      },
+      "engines": {
+        "vscode": "^1.95.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.19.tgz",
+      "integrity": "sha512-pb1Uqj5WJP7wrcbLU7Ru4QtA0+3kAXrkutGiD26wUKzSMgNNaPARTUDQmElUXp64kh3cWdou3Q0C7qwwxqSFmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.104.0.tgz",
+      "integrity": "sha512-0KwoU2rZ2ecsTGFxo4K1+f+AErRsYW0fsp6A0zufzGuhyczc2IoKqYqcwXidKXmy2u8YB2GsYsOtiI9Izx3Tig==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/vscode-repo-manager/package.json
+++ b/vscode-repo-manager/package.json
@@ -1,0 +1,192 @@
+{
+  "name": "vscode-repo-manager",
+  "displayName": "Repo Manager",
+  "description": "Manage and open your Git repositories from a dedicated view.",
+  "version": "0.0.1",
+  "publisher": "localdev",
+  "engines": {
+    "vscode": "^1.95.0"
+  },
+  "categories": ["Other"],
+  "activationEvents": [
+    "onView:repoManager.repos",
+    "onCommand:repoManager.scanWorkspaceRepos",
+    "onCommand:repoManager.addRepo",
+    "onCommand:repoManager.cloneRepo",
+    "onStartupFinished"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "repoManager",
+          "title": "Repos",
+          "icon": "media/activity-icon.svg"
+        }
+      ]
+    },
+    "views": {
+      "repoManager": [
+        {
+          "id": "repoManager.repos",
+          "name": "Repositories"
+        }
+      ]
+    },
+    "commands": [
+      {
+        "command": "repoManager.refresh",
+        "title": "Repo Manager: Refresh",
+        "category": "Repo Manager",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "repoManager.scanWorkspaceRepos",
+        "title": "Repo Manager: Scan Workspace for Repos",
+        "category": "Repo Manager",
+        "icon": "$(search)"
+      },
+      {
+        "command": "repoManager.addRepo",
+        "title": "Repo Manager: Add Repository Folder",
+        "category": "Repo Manager",
+        "icon": "$(folder)"
+      },
+      {
+        "command": "repoManager.removeRepo",
+        "title": "Repo Manager: Remove Repository",
+        "category": "Repo Manager",
+        "icon": "$(trash)"
+      },
+      {
+        "command": "repoManager.openRepo",
+        "title": "Repo Manager: Open Repository",
+        "category": "Repo Manager",
+        "icon": "$(folder-opened)"
+      },
+      {
+        "command": "repoManager.cloneRepo",
+        "title": "Repo Manager: Clone Repository",
+        "category": "Repo Manager",
+        "icon": "$(cloud-download)"
+      },
+      {
+        "command": "repoManager.fetchRepo",
+        "title": "Repo Manager: Fetch",
+        "category": "Repo Manager",
+        "icon": "$(cloud-download)"
+      },
+      {
+        "command": "repoManager.pullRepo",
+        "title": "Repo Manager: Pull",
+        "category": "Repo Manager",
+        "icon": "$(cloud-download)"
+      },
+      {
+        "command": "repoManager.pushRepo",
+        "title": "Repo Manager: Push",
+        "category": "Repo Manager",
+        "icon": "$(cloud-upload)"
+      }
+    ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "repoManager.refresh",
+          "when": "view == repoManager.repos",
+          "group": "navigation"
+        },
+        {
+          "command": "repoManager.scanWorkspaceRepos",
+          "when": "view == repoManager.repos",
+          "group": "navigation"
+        },
+        {
+          "command": "repoManager.addRepo",
+          "when": "view == repoManager.repos",
+          "group": "navigation"
+        },
+        {
+          "command": "repoManager.cloneRepo",
+          "when": "view == repoManager.repos",
+          "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "repoManager.openRepo",
+          "when": "view == repoManager.repos && viewItem == repoItem",
+          "group": "inline"
+        },
+        {
+          "command": "repoManager.fetchRepo",
+          "when": "view == repoManager.repos && viewItem == repoItem",
+          "group": "2_git@1"
+        },
+        {
+          "command": "repoManager.pullRepo",
+          "when": "view == repoManager.repos && viewItem == repoItem",
+          "group": "2_git@2"
+        },
+        {
+          "command": "repoManager.pushRepo",
+          "when": "view == repoManager.repos && viewItem == repoItem",
+          "group": "2_git@3"
+        },
+        {
+          "command": "repoManager.removeRepo",
+          "when": "view == repoManager.repos && viewItem == repoItem",
+          "group": "3_cleanup"
+        }
+      ]
+    },
+    "configuration": {
+      "title": "Repo Manager",
+      "properties": {
+        "repoManager.autoScanOnStartup": {
+          "type": "boolean",
+          "default": true,
+          "description": "Scan workspace for Git repositories on startup."
+        },
+        "repoManager.openInNewWindow": {
+          "type": "boolean",
+          "default": false,
+          "description": "Open repositories in a new window."
+        },
+        "repoManager.includeGlobs": {
+          "type": "array",
+          "default": ["**/.git/config"],
+          "items": { "type": "string" },
+          "description": "Glob patterns to search for Git repositories."
+        },
+        "repoManager.excludeGlobs": {
+          "type": "array",
+          "default": ["**/node_modules/**", "**/.git/**", "**/out/**", "**/dist/**", "**/.next/**"],
+          "items": { "type": "string" },
+          "description": "Glob patterns to exclude when scanning."
+        }
+      }
+    }
+  },
+  "extensionKind": ["workspace"],
+  "repository": {
+    "type": "git",
+    "url": ""
+  },
+  "bugs": {
+    "url": ""
+  },
+  "homepage": "",
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "lint": "echo \"No linter configured\""
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.11",
+    "@types/vscode": "^1.95.0",
+    "typescript": "^5.6.3"
+  }
+}

--- a/vscode-repo-manager/src/extension.ts
+++ b/vscode-repo-manager/src/extension.ts
@@ -1,0 +1,51 @@
+import * as vscode from 'vscode';
+import { RepoTreeProvider, RepoItem } from './tree/RepoTreeProvider';
+import { GitService } from './git/GitService';
+
+export async function activate(context: vscode.ExtensionContext) {
+  const gitService = new GitService();
+  const tree = new RepoTreeProvider(context, gitService);
+  const treeView = vscode.window.createTreeView('repoManager.repos', {
+    treeDataProvider: tree,
+    showCollapseAll: false,
+  });
+
+  context.subscriptions.push(treeView);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('repoManager.refresh', () => tree.refresh()),
+    vscode.commands.registerCommand('repoManager.scanWorkspaceRepos', async () => {
+      await tree.scanWorkspaceRepos();
+    }),
+    vscode.commands.registerCommand('repoManager.addRepo', async () => {
+      await tree.addRepo();
+    }),
+    vscode.commands.registerCommand('repoManager.removeRepo', async (item: RepoItem) => {
+      await tree.removeRepo(item);
+    }),
+    vscode.commands.registerCommand('repoManager.openRepo', async (item: RepoItem) => {
+      await tree.openRepo(item);
+    }),
+    vscode.commands.registerCommand('repoManager.cloneRepo', async () => {
+      await tree.cloneRepo();
+    }),
+    vscode.commands.registerCommand('repoManager.fetchRepo', async (item: RepoItem) => {
+      await tree.gitAction(item, 'fetch');
+    }),
+    vscode.commands.registerCommand('repoManager.pullRepo', async (item: RepoItem) => {
+      await tree.gitAction(item, 'pull');
+    }),
+    vscode.commands.registerCommand('repoManager.pushRepo', async (item: RepoItem) => {
+      await tree.gitAction(item, 'push');
+    })
+  );
+
+  const autoScan = vscode.workspace.getConfiguration('repoManager').get<boolean>('autoScanOnStartup', true);
+  if (autoScan) {
+    setTimeout(() => tree.scanWorkspaceRepos(), 500);
+  }
+}
+
+export function deactivate() {
+  // noop
+}

--- a/vscode-repo-manager/src/git/GitService.ts
+++ b/vscode-repo-manager/src/git/GitService.ts
@@ -1,0 +1,33 @@
+import * as cp from 'child_process';
+import * as path from 'path';
+
+export class GitService {
+  async execGit(args: string[], cwd: string): Promise<{ stdout: string; stderr: string }> {
+    return new Promise((resolve, reject) => {
+      const child = cp.spawn('git', args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (d) => (stdout += String(d)));
+      child.stderr.on('data', (d) => (stderr += String(d)));
+      child.on('error', reject);
+      child.on('close', (code) => {
+        if (code === 0) resolve({ stdout, stderr });
+        else reject(new Error(stderr || `git ${args.join(' ')} failed with code ${code}`));
+      });
+    });
+  }
+
+  async clone(url: string, parentFolder: string): Promise<string> {
+    const name = deriveRepoFolderName(url);
+    await this.execGit(['clone', url, name], parentFolder);
+    return name;
+  }
+}
+
+function deriveRepoFolderName(url: string): string {
+  const cleaned = url.replace(/[\s"'`]/g, '');
+  const withoutGit = cleaned.endsWith('.git') ? cleaned.slice(0, -4) : cleaned;
+  const parts = withoutGit.split(/[/:]/).filter(Boolean);
+  const final = parts[parts.length - 1] ?? 'repo';
+  return final.toLowerCase().replace(/[^a-z0-9._-]/gi, '-');
+}

--- a/vscode-repo-manager/src/tree/RepoTreeProvider.ts
+++ b/vscode-repo-manager/src/tree/RepoTreeProvider.ts
@@ -1,0 +1,202 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import { GitService } from '../git/GitService';
+
+export type GitAction = 'fetch' | 'pull' | 'push';
+
+export interface RepoItem extends vscode.TreeItem {
+  repoPath: string;
+}
+
+interface StoredState {
+  repos: string[];
+}
+
+export class RepoTreeProvider implements vscode.TreeDataProvider<RepoItem> {
+  private readonly _onDidChangeTreeData = new vscode.EventEmitter<RepoItem | undefined | void>();
+  readonly onDidChangeTreeData: vscode.Event<RepoItem | undefined | void> = this._onDidChangeTreeData.event;
+
+  private repos: string[] = [];
+
+  constructor(
+    private readonly context: vscode.ExtensionContext,
+    private readonly gitService: GitService
+  ) {
+    const state = this.getState();
+    this.repos = [...new Set(state.repos.filter((p) => !!p))].sort();
+  }
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire();
+    this.saveState();
+  }
+
+  getTreeItem(element: RepoItem): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(): Thenable<RepoItem[]> {
+    if (!this.repos.length) {
+      const item = new vscode.TreeItem('No repositories', vscode.TreeItemCollapsibleState.None);
+      item.iconPath = new vscode.ThemeIcon('warning');
+      item.tooltip = 'Use the + button to add a repository or scan the workspace.';
+      return Promise.resolve([]);
+    }
+
+    const items = this.repos.map((repoPath) => this.createRepoItem(repoPath));
+    return Promise.resolve(items);
+  }
+
+  private createRepoItem(repoPath: string): RepoItem {
+    const repoName = path.basename(repoPath);
+    const item = new vscode.TreeItem(repoName, vscode.TreeItemCollapsibleState.None) as RepoItem;
+    item.contextValue = 'repoItem';
+    item.resourceUri = vscode.Uri.file(repoPath);
+    item.tooltip = repoPath;
+    item.iconPath = new vscode.ThemeIcon('source-control');
+    (item as RepoItem).repoPath = repoPath;
+    item.command = {
+      title: 'Open Repository',
+      command: 'repoManager.openRepo',
+      arguments: [item],
+    };
+    return item as RepoItem;
+  }
+
+  async addRepo(): Promise<void> {
+    const selected = await vscode.window.showOpenDialog({
+      canSelectFiles: false,
+      canSelectFolders: true,
+      canSelectMany: false,
+      openLabel: 'Select Repository Folder',
+    });
+    if (!selected || !selected[0]) return;
+    const repoPath = selected[0].fsPath;
+    if (!this.isGitRepo(repoPath)) {
+      const pick = await vscode.window.showWarningMessage(
+        'Selected folder does not appear to be a Git repository. Add anyway?',
+        'Add',
+        'Cancel'
+      );
+      if (pick !== 'Add') return;
+    }
+    this.repos = [...new Set([...this.repos, repoPath])].sort();
+    this.refresh();
+  }
+
+  async removeRepo(item: RepoItem): Promise<void> {
+    this.repos = this.repos.filter((p) => p !== item.repoPath);
+    this.refresh();
+  }
+
+  async openRepo(item: RepoItem): Promise<void> {
+    const openInNew = vscode.workspace.getConfiguration('repoManager').get<boolean>('openInNewWindow', false);
+    await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(item.repoPath), openInNew);
+  }
+
+  async cloneRepo(): Promise<void> {
+    const url = await vscode.window.showInputBox({
+      prompt: 'Enter Git clone URL',
+      placeHolder: 'https://github.com/owner/repo.git or git@github.com:owner/repo.git',
+      ignoreFocusOut: true,
+      validateInput: (value) => (value.trim().length === 0 ? 'URL is required' : undefined),
+    });
+    if (!url) return;
+
+    const targetFolder = await vscode.window.showOpenDialog({
+      canSelectFiles: false,
+      canSelectFolders: true,
+      canSelectMany: false,
+      openLabel: 'Select destination folder',
+    });
+    if (!targetFolder || !targetFolder[0]) return;
+
+    const parent = targetFolder[0].fsPath;
+    const name = await this.gitService.clone(url, parent);
+    const repoPath = path.join(parent, name);
+    if (fs.existsSync(repoPath)) {
+      this.repos = [...new Set([...this.repos, repoPath])].sort();
+      this.refresh();
+      const open = await vscode.window.showInformationMessage('Repository cloned. Open it now?', 'Open', 'Later');
+      if (open === 'Open') {
+        await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(repoPath), true);
+      }
+    }
+  }
+
+  async gitAction(item: RepoItem, action: 'fetch' | 'pull' | 'push'): Promise<void> {
+    const repoPath = item.repoPath;
+    const terminalName = `Repo Manager: ${action} ${path.basename(repoPath)}`;
+    const terminal = vscode.window.createTerminal({ name: terminalName, cwd: repoPath });
+    terminal.show(true);
+    switch (action) {
+      case 'fetch':
+        terminal.sendText('git fetch --all --prune');
+        break;
+      case 'pull':
+        terminal.sendText('git pull --ff-only');
+        break;
+      case 'push':
+        terminal.sendText('git push');
+        break;
+    }
+  }
+
+  async scanWorkspaceRepos(): Promise<void> {
+    const includeGlobs = vscode.workspace.getConfiguration('repoManager').get<string[]>('includeGlobs', ['**/.git/config']);
+    const excludeGlobs = vscode.workspace.getConfiguration('repoManager').get<string[]>('excludeGlobs', [
+      '**/node_modules/**',
+      '**/.git/**',
+      '**/out/**',
+      '**/dist/**',
+      '**/.next/**',
+    ]);
+
+    const folders = vscode.workspace.workspaceFolders ?? [];
+    const found = new Set<string>(this.repos);
+
+    for (const folder of folders) {
+      const uris = await vscode.workspace.findFiles(
+        new vscode.RelativePattern(folder, includeGlobs[0]),
+        new vscode.RelativePattern(folder, `{${excludeGlobs.join(',')}}`),
+        1000
+      );
+      for (const uri of uris) {
+        const repoPath = path.dirname(path.dirname(uri.fsPath));
+        if (this.isGitRepo(repoPath)) {
+          found.add(repoPath);
+        }
+      }
+    }
+
+    this.repos = Array.from(found).sort();
+    this.refresh();
+    vscode.window.showInformationMessage(`Repo Manager: found ${this.repos.length} repositories`);
+  }
+
+  private isGitRepo(folderPath: string): boolean {
+    try {
+      return fs.existsSync(path.join(folderPath, '.git'));
+    } catch {
+      return false;
+    }
+  }
+
+  private getState(): StoredState {
+    const raw = this.context.globalState.get<string>('repos', '[]');
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        return { repos: parsed.filter((p) => typeof p === 'string') };
+      }
+      return { repos: [] };
+    } catch {
+      return { repos: [] };
+    }
+  }
+
+  private saveState(): void {
+    this.context.globalState.update('repos', JSON.stringify(this.repos));
+  }
+}

--- a/vscode-repo-manager/tsconfig.json
+++ b/vscode-repo-manager/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "out",
+    "rootDir": "src",
+    "strict": true,
+    "sourceMap": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "moduleResolution": "node",
+    "types": ["node", "vscode"],
+    "skipLibCheck": true
+  },
+  "exclude": ["node_modules", ".vscode-test"]
+}


### PR DESCRIPTION
Add a VS Code extension for managing Git repositories, providing a dedicated view and commands for common repo operations.

This PR delivers the initial scaffold and core functionality for a "Repo Manager" VS Code extension, enabling users to organize, open, and perform basic Git actions on their repositories directly from a VS Code sidebar. It includes a tree view, commands for scanning, adding, removing, cloning, opening, fetching, pulling, and pushing, along with persistent storage for the repo list and configurable settings.

---
<a href="https://cursor.com/background-agent?bcId=bc-ccd1401e-f1fd-4c55-a52e-6eee88943707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ccd1401e-f1fd-4c55-a52e-6eee88943707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

